### PR TITLE
Fixing another assumption

### DIFF
--- a/pinhead/pinhead.py
+++ b/pinhead/pinhead.py
@@ -80,12 +80,12 @@ def pCPUInfo():
 
 	#print "%d cpus, %d threadsPerCore, %d coresPerSocket, %d sockets" % (cpus, threadsPerCore, coresPerSocket, sockets)
 
-        ''' We can't trust that the cores are in sequential order. i e 0-11,
-        E. g. for Intel(R) Xeon(R) CPU E5-2670 v3 which is a 12 core cpu the enumeration in 0-5, 8-13. '''
-        coreEnumeration = []
-        for i in range(0, coresPerSocket):
-                coreEnumeration.append(open('/sys/devices/system/cpu/cpu' + str(i) + '/topology/core_id', 'r').read().strip())
-        cpuTree=[[[['s'+str(k)+'c'+str(i)+'t'+str(j), None, []] for j in range(0, threadsPerCore)] for i in coreEnumeration] for k in range(0, sockets)]
+	''' We can't trust that the cores are in sequential order. i e 0-11,
+	    E. g. for Intel(R) Xeon(R) CPU E5-2670 v3 which is a 12 core cpu the enumeration in 0-5, 8-13. '''
+	coreEnumeration = set() # Using set() so we automatically get all unique core_id's
+	for i in range(0, cpus):
+		coreEnumeration.add(open('/sys/devices/system/cpu/cpu' + str(i) + '/topology/core_id', 'r').read().strip())
+	cpuTree=[[[['s'+str(k)+'c'+str(i)+'t'+str(j), None, []] for j in range(0, threadsPerCore)] for i in coreEnumeration] for k in range(0, sockets)]
 
 	''' We now have a cpuTree structure made of nested lists. The hierarchy goes: cpuTree -> sockets -> cores -> threads.
 	E.g. for a 2x4x2 configuration, as detected above:


### PR DESCRIPTION
Noticed that you are utilizing my little hack, just thought you might want to know there is an update.

The last commit stoped trusting that all core_id's are available in the range of coresPerSocket. Instead it creates a set of all core_id's by iterating over all available cores.